### PR TITLE
Delete example deploy file

### DIFF
--- a/src/main/deploy/example.txt
+++ b/src/main/deploy/example.txt
@@ -1,3 +1,0 @@
-Files placed in this directory will be deployed to the RoboRIO into the
-'deploy' directory in the home folder. Use the 'Filesystem.getDeployDirectory' wpilib function
-to get a proper path relative to the deploy directory.


### PR DESCRIPTION
We do not use this feature of GradleRIO (and if we do, this example file isn't needed).