### PR TITLE
Add empty functions for disabled mode

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -92,6 +92,20 @@ public class Robot extends TimedRobot {
   }
 
   /**
+   * This function is called when initializing disabled mode.
+   */
+  @Override
+  public void disabledInit() {
+  }
+
+  /**
+   * This function is called periodically during disabled mode.
+   */
+  @Override
+  public void disabledPeriodic() {
+  }
+
+  /**
    * This autonomous (along with the chooser code above) shows how to select
    * between different autonomous modes using the dashboard. The sendable chooser
    * code works with the Java SmartDashboard. If you prefer the LabVIEW Dashboard,


### PR DESCRIPTION
In addition to the teleop and autonomous modes, the robot code also has the concept of a disabled mode, controlled via [`disabledInit()`](https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/IterativeRobotBase.html#disabledInit()) and [`disabledPeriodic()`](https://first.wpi.edu/FRC/roborio/release/docs/java/edu/wpi/first/wpilibj/IterativeRobotBase.html#disabledPeriodic()). I don't have any actual use for these functions at the moment, but this will suppress these two errors:
```
********** Robot program starting **********
Default disabledInit() method... Override me!
Default disabledPeriodic() method... Override me!
```