### PR TITLE
Switch to Shuffleboard

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -1,11 +1,18 @@
 package frc.robot;
 
+import java.util.Map;
+
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardLayout;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
+import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
+import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
 
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
@@ -56,6 +63,28 @@ public class Robot extends TimedRobot {
   // Joysticks
   private final Joystick driveController = new Joystick(0);
   private final Joystick manipulateController = new Joystick(1);
+
+  // Shuffleboard
+  private final ShuffleboardTab generalTab = Shuffleboard.getTab("General");
+  private final ShuffleboardLayout stateLayout = generalTab.getLayout("State", BuiltInLayouts.kGrid).withPosition(0, 0)
+      .withSize(3, 1).withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
+  private final NetworkTableEntry controlPanelModeEntry = stateLayout.add("Control panel mode", false)
+      .withWidget(BuiltInWidgets.kToggleSwitch).getEntry();
+  private final ShuffleboardLayout autonomousLayout = generalTab.getLayout("Autonomous", BuiltInLayouts.kGrid)
+      .withPosition(3, 0).withSize(3, 1)
+      .withProperties(Map.of("Label position", "HIDDEN", "Number of columns", 1, "Number of rows", 1));
+  private final ShuffleboardLayout drivingLayout = generalTab.getLayout("Driving", BuiltInLayouts.kList)
+      .withPosition(0, 1).withSize(3, 3);
+  private final ShuffleboardLayout launchingLayout = generalTab.getLayout("Launching", BuiltInLayouts.kList)
+      .withPosition(3, 1).withSize(1, 1);
+  private final ShuffleboardLayout controlPanelLayout = generalTab.getLayout("Color Sensing", BuiltInLayouts.kGrid)
+      .withPosition(3, 2).withSize(3, 2).withProperties(Map.of("Number of columns", 2, "Number of rows", 2));
+  private final NetworkTableEntry detectedColorEntry = controlPanelLayout.add("Detected color", "N/A").getEntry();
+  private final NetworkTableEntry confidenceEntry = controlPanelLayout.add("Confidence", 0).getEntry();
+  private final NetworkTableEntry targetColorEntry = controlPanelLayout.add("Target Color", "N/A").getEntry();
+  private final NetworkTableEntry targetSpinEntry = controlPanelLayout.add("Target Spins", 0).getEntry();
+  private final ShuffleboardLayout visionLayout = generalTab.getLayout("Vision", BuiltInLayouts.kList).withPosition(6,
+      0);
 
   /**
    * This function is run when the robot is first started up and should be used

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -79,18 +79,18 @@ public class Robot extends TimedRobot {
   private final ShuffleboardLayout autonomousLayout = generalTab.getLayout("Autonomous", BuiltInLayouts.kGrid)
       .withPosition(3, 0).withSize(3, 1)
       .withProperties(Map.of("Label position", "HIDDEN", "Number of columns", 1, "Number of rows", 1));
-  private final ShuffleboardLayout drivingLayout = generalTab.getLayout("Driving", BuiltInLayouts.kList)
-      .withPosition(0, 1).withSize(3, 3);
-  private final ShuffleboardLayout launchingLayout = generalTab.getLayout("Launching", BuiltInLayouts.kList)
-      .withPosition(3, 1).withSize(1, 1);
+  private final ShuffleboardLayout drivingLayout = generalTab.getLayout("Driving", BuiltInLayouts.kGrid)
+      .withPosition(0, 1).withSize(3, 3).withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
+  private final ShuffleboardLayout launchingLayout = generalTab.getLayout("Launching", BuiltInLayouts.kGrid)
+      .withPosition(3, 1).withSize(1, 1).withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
   private final ShuffleboardLayout controlPanelLayout = generalTab.getLayout("Color Sensing", BuiltInLayouts.kGrid)
       .withPosition(3, 2).withSize(3, 2).withProperties(Map.of("Number of columns", 2, "Number of rows", 2));
   private final NetworkTableEntry detectedColorEntry = controlPanelLayout.add("Detected color", "N/A").getEntry();
   private final NetworkTableEntry confidenceEntry = controlPanelLayout.add("Confidence", 0).getEntry();
   private final NetworkTableEntry targetColorEntry = controlPanelLayout.add("Target Color", "N/A").getEntry();
   private final NetworkTableEntry targetSpinEntry = controlPanelLayout.add("Target Spins", 0).getEntry();
-  private final ShuffleboardLayout visionLayout = generalTab.getLayout("Vision", BuiltInLayouts.kList).withPosition(6,
-      0);
+  private final ShuffleboardLayout visionLayout = generalTab.getLayout("Vision", BuiltInLayouts.kGrid)
+      .withPosition(6, 0).withSize(1, 1).withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
 
   /**
    * This function is run when the robot is first started up and should be used


### PR DESCRIPTION
This pull request removes the SmartDashboard code, and adds in new Shuffleboard widgets, organized into layouts *by* the robot code, minimizing the effort required by the drive station users. This is what the new tab looks like:
![image](https://user-images.githubusercontent.com/13039555/74611416-a380d780-50c9-11ea-8e00-3e7970371fb9.png)
Some of these layouts are empty placeholders that are to be filled in by other PRs.

This pull request also reorganizes the robot code into well defined sections that are obeyed by the member variable order, `teleopPeriodic()`, and the Shuffleboard tab:
- Joystick input. This is what is required at the very beginning of a robot loop.
- General state.
- Driving.
- Launching.
- Color sensing.
- Vision, specifically that of the USB camera.
- Shuffleboard work. I think of this is sending feedback at the very end of a robot loop.

To better align with this vision, the different control panel functions have been merged into one. This pull request also fixes a bug where the spin counter couldn't be changed, because of improper use of the `Joystick.getRawButtonPressed()` function.

More info on Shuffleboard is available at its [official documentation](https://docs.wpilib.org/en/latest/docs/software/wpilib-tools/shuffleboard/index.html).