### PR TITLE
Add launching mode and intake

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -77,6 +77,15 @@ public final class Constants {
   /** The speed to set the control panel motor to. */
   // TODO: Tune this value.
   public static final double kSpeedControlPanel = 0.25;
+  /** The speed to set the intake motor to. */
+  // TODO: Tune this value.
+  public static final double kSpeedIntake = 0.75;
+  /** The speed to set the intake motor to. */
+  // TODO: Tune this value.
+  public static final double kSpeedLauncher = 0.75;
+  /** The speed to set the belt motor to. */
+  // TODO: Tune this value.
+  public static final double kSpeedBelt = 0.50;
   /**
    * The proportionality constant to use for correcting error in maintaining a distance from an
    * object.

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -91,7 +91,7 @@ public final class Constants {
    * object.
    */
   // TODO: Tune this measurement.
-  public static final double kP = 0.05;
+  public static final double kP = 0.3;
 
   // Constant Calculations
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -81,8 +81,7 @@ public final class Constants {
   // TODO: Tune this value.
   public static final double kSpeedIntake = 0.75;
   /** The speed to set the intake motor to. */
-  // TODO: Tune this value.
-  public static final double kSpeedLauncher = 0.75;
+  public static final double kSpeedLauncher = 1.0;
   /** The speed to set the belt motor to. */
   // TODO: Tune this value.
   public static final double kSpeedBelt = 0.50;

--- a/src/main/java/frc/robot/DriveStation.java
+++ b/src/main/java/frc/robot/DriveStation.java
@@ -34,6 +34,11 @@ public final class DriveStation {
   /** The button ID of RS, activated by clicking the right stick. */
   public static final int kIDButtonRS = 10;
 
+  // POV IDs
+
+  /** The POV ID of the D-pad. */
+  public static final int kIdPovDpad = 0;
+
   // Axis IDs
 
   /** The axis ID of the X dimension of the left analog stick. */

--- a/src/main/java/frc/robot/DriveStation.java
+++ b/src/main/java/frc/robot/DriveStation.java
@@ -14,25 +14,25 @@ public final class DriveStation {
   // Button IDs
 
   /** The button ID of the A button. */
-  public static final int kIDButtonA = 1;
+  public static final int kIdButtonA = 1;
   /** The button ID of the B button. */
-  public static final int kIDButtonB = 2;
+  public static final int kIdButtonB = 2;
   /** The button ID of the X button. */
-  public static final int kIDButtonX = 3;
+  public static final int kIdButtonX = 3;
   /** The button ID of the Y button. */
-  public static final int kIDButtonY = 4;
+  public static final int kIdButtonY = 4;
   /** The button ID of LB, the right bumper. */
-  public static final int kIDButtonLB = 5;
+  public static final int kIdButtonLb = 5;
   /** The button ID of RB, the right bumper. */
-  public static final int kIDButtonRB = 6;
+  public static final int kIdButtonRb = 6;
   /** The button ID of the back button, also select on some controllers. */
-  public static final int kIDButtonBack = 7;
+  public static final int kIdButtonBack = 7;
   /** The button ID of the start button. */
-  public static final int kIDButtonStart = 8;
+  public static final int kIdButtonStart = 8;
   /** The button ID of LS, activated by clicking the left stick. */
-  public static final int kIDButtonLS = 9;
+  public static final int kIdButtonLs = 9;
   /** The button ID of RS, activated by clicking the right stick. */
-  public static final int kIDButtonRS = 10;
+  public static final int kIdButtonRs = 10;
 
   // POV IDs
 
@@ -42,15 +42,15 @@ public final class DriveStation {
   // Axis IDs
 
   /** The axis ID of the X dimension of the left analog stick. */
-  public static final int kIDAxisLeftX = 0;
+  public static final int kIdAxisLeftX = 0;
   /** The axis ID of the Y dimension of the left analog stick. */
-  public static final int kIDAxisLeftY = 1;
+  public static final int kIdAxisLeftY = 1;
   /** The axis ID of LT, the left trigger. */
-  public static final int kIDAxisLT = 2;
+  public static final int kIdAxisLt = 2;
   /** The axis ID of RT, the right trigger. */
-  public static final int kIDAxisRT = 3;
+  public static final int kIdAxisRt = 3;
   /** The axis ID of the X dimension of the right analog stick. */
-  public static final int kIDAxisRightX = 4;
+  public static final int kIdAxisRightX = 4;
   /** The axis ID of the Y dimension of the right analog stick. */
-  public static final int kIDAxisRightY = 5;
+  public static final int kIdAxisRightY = 5;
 }

--- a/src/main/java/frc/robot/RoboRIO.java
+++ b/src/main/java/frc/robot/RoboRIO.java
@@ -62,4 +62,16 @@ public final class RoboRIO {
    */
   public static final double kUltrasonicRange =
       kMaximumReadingUltrasonic - kMinimumReadingUltrasonic;
+
+  // Digital Inputs
+  /**
+   * The port of the photoelectric sensor at the bottom of the storage, where balls enter. This is a
+   * 42EF-D1MNAK-A2.
+   */
+  public static final int kPortPhotoelectricSensorEnter = 0;
+  /**
+   * The port of the photoelectric sensor at the top of the storage, where balls leave. This is a
+   * 42JT-F5LET1-A2.
+   */
+  public static final int kPortPhotoelectricSensorExit = 1;
 }

--- a/src/main/java/frc/robot/RoboRIO.java
+++ b/src/main/java/frc/robot/RoboRIO.java
@@ -18,8 +18,12 @@ public final class RoboRIO {
   public static final int kPortMotorDriveBackRight = 4;
   /** The port of the control panel motor. */
   public static final int kPortMotorControlPanel = 6;
+  /** The port of the intake motor. */
+  public static final int kPortMotorIntake = 7;
   /** The port of the left launcher motor. */
   public static final int kPortMotorLauncherLeft = 8;
+  /** The port of the conveyor belt. */
+  public static final int kPortMotorBelt = 10;
   /**
    * The port of the right launcher motor. On the electronics board, this is #8b, but this couldn't be
    * replicated due to software limitaitons.

--- a/src/main/java/frc/robot/RoboRIO.java
+++ b/src/main/java/frc/robot/RoboRIO.java
@@ -68,10 +68,10 @@ public final class RoboRIO {
    * The port of the photoelectric sensor at the bottom of the storage, where balls enter. This is a
    * 42EF-D1MNAK-A2.
    */
-  public static final int kPortPhotoelectricSensorEnter = 0;
+  public static final int kPortPhotoelectricSensorEnter = 1;
   /**
    * The port of the photoelectric sensor at the top of the storage, where balls leave. This is a
    * 42JT-F5LET1-A2.
    */
-  public static final int kPortPhotoelectricSensorExit = 1;
+  public static final int kPortPhotoelectricSensorExit = 2;
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -298,11 +298,6 @@ public class Robot extends TimedRobot {
     if (m_buttonManipPressBack) {
       m_isInLaunchingMode = !m_isInLaunchingMode;
       ShuffleboardHelper.m_entryLaunchingMode.setBoolean(m_isInLaunchingMode);
-      // Disallow being in both modes simultaneously.
-      if (m_isInControlPanelMode) {
-        m_isInControlPanelMode = false;
-        ShuffleboardHelper.m_entryControlPanelMode.setBoolean(false);
-      }
     } else {
       m_isInLaunchingMode = ShuffleboardHelper.m_entryLaunchingMode
           .getBoolean(m_isInLaunchingMode);
@@ -311,11 +306,6 @@ public class Robot extends TimedRobot {
       m_isInControlPanelMode = !m_isInControlPanelMode;
       ShuffleboardHelper.m_entryControlPanelMode
           .setBoolean(m_isInControlPanelMode);
-      // Disallow being in both modes simultaneously.
-      if (m_isInLaunchingMode) {
-        m_isInLaunchingMode = false;
-        ShuffleboardHelper.m_entryLaunchingMode.setBoolean(false);
-      }
     } else {
       m_isInControlPanelMode = ShuffleboardHelper.m_entryControlPanelMode
           .getBoolean(m_isInControlPanelMode);
@@ -332,23 +322,39 @@ public class Robot extends TimedRobot {
     }
 
     // Set the Shuffleboard control panel values to their defaults when not enabled.
-    if (!m_isInControlPanelMode
-        && m_isInControlPanelModeLastLoop != m_isInControlPanelMode) {
-      m_detectedColorString = "N/A";
-      m_lastDetectedColorString = "N/A";
-      m_targetControlPanelColor = "N/A";
-      m_controlPanelSpinAmount = 0;
-      ShuffleboardHelper.m_entryDetectedColor.setString(m_detectedColorString);
-      ShuffleboardHelper.m_entryTargetColor
-          .setString(m_targetControlPanelColor);
-      ShuffleboardHelper.m_entryTargetSpin.setDouble(m_controlPanelSpinAmount);
-      ShuffleboardHelper.m_entryConfidence.setDouble(0);
+    if (m_isInControlPanelModeLastLoop != m_isInControlPanelMode) {
+      if (m_isInControlPanelMode) {
+        // Disallow being in both modes simultaneously.
+        if (m_isInLaunchingMode) {
+          m_isInLaunchingMode = false;
+          ShuffleboardHelper.m_entryLaunchingMode.setBoolean(false);
+        }
+      } else {
+        m_detectedColorString = "N/A";
+        m_lastDetectedColorString = "N/A";
+        m_targetControlPanelColor = "N/A";
+        m_controlPanelSpinAmount = 0;
+        ShuffleboardHelper.m_entryDetectedColor
+            .setString(m_detectedColorString);
+        ShuffleboardHelper.m_entryTargetColor
+            .setString(m_targetControlPanelColor);
+        ShuffleboardHelper.m_entryTargetSpin
+            .setDouble(m_controlPanelSpinAmount);
+        ShuffleboardHelper.m_entryConfidence.setDouble(0);
+      }
     }
-    if (!m_isInLaunchingMode
-        && m_isInLaunchingModeLastLoop != m_isInLaunchingMode) {
-      m_launchBall = false;
-      ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
-      ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
+    if (m_isInLaunchingModeLastLoop != m_isInLaunchingMode) {
+      if (m_isInLaunchingMode) {
+        // Disallow being in both modes simultaneously.
+        if (m_isInControlPanelMode) {
+          m_isInControlPanelMode = false;
+          ShuffleboardHelper.m_entryControlPanelMode.setBoolean(false);
+        }
+      } else {
+        m_launchBall = false;
+        ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
+        ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
+      }
     }
     m_isInControlPanelModeLastLoop = m_isInControlPanelMode;
     m_isInLaunchingModeLastLoop = m_isInLaunchingMode;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -73,9 +73,9 @@ public class Robot extends TimedRobot {
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorEnter);
   private final DigitalInput photoelectricSensorExit =
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorExit);
-  private boolean ballDetectedEnterLastLoop = false;
-  private int ballsInStorage = 0;
-  private boolean ballDetectedExitLastLoop = false;
+  private boolean m_ballDetectedEnterLastLoop = false;
+  private int m_ballsInStorage = 0;
+  private boolean m_ballDetectedExitLastLoop = false;
 
   // Launching
   WPI_VictorSPX m_motorLauncherLeft =
@@ -239,8 +239,8 @@ public class Robot extends TimedRobot {
     m_isInControlPanelMode = false;
     m_isInControlPanelModeLastLoop = false;
 
-    ballDetectedEnterLastLoop = false;
-    ballsInStorage = 0;
+    m_ballDetectedEnterLastLoop = false;
+    m_ballsInStorage = 0;
 
     m_launchBall = false;
 
@@ -396,7 +396,7 @@ public class Robot extends TimedRobot {
     // If the manipulator holds LT, and the storage isn't full, activate the intake.
     // TODO: Is this ballsInStorage check putting too much trust in the sensor?
     if (m_controllerDrive.getRawAxis(DriveStation.kIdAxisLt) > 0.50
-        && ballsInStorage < 3)
+        && m_ballsInStorage < 3)
       m_motorIntake.set(Constants.kSpeedIntake);
     else
       m_motorIntake.set(0);
@@ -409,27 +409,27 @@ public class Robot extends TimedRobot {
     boolean ballDetectedExit = !photoelectricSensorExit.get();
     // Advance the belt if there's a ball in the enter spot, and more room above.
     if (ballDetectedEnter) {
-      if (!ballDetectedEnterLastLoop)
-        ++ballsInStorage;
-      if (ballsInStorage < 3)
+      if (!m_ballDetectedEnterLastLoop)
+        ++m_ballsInStorage;
+      if (m_ballsInStorage < 3)
         advanceBelt = true;
       ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(ballDetectedEnter);
-      ShuffleboardHelper.m_entryBallsInStorage.setDouble(ballsInStorage);
+      ShuffleboardHelper.m_entryBallsInStorage.setDouble(m_ballsInStorage);
     } else if (!ballDetectedEnter) {
       ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(ballDetectedEnter);
       advanceBelt = false;
     }
     // Keep track of balls exiting.
     if (!ballDetectedExit) {
-      if (ballDetectedExitLastLoop)
-        --ballsInStorage;
+      if (m_ballDetectedExitLastLoop)
+        --m_ballsInStorage;
       // Stop launching the balls if we have finished.
-      if (m_launchBall && ballsInStorage == 0) {
+      if (m_launchBall && m_ballsInStorage == 0) {
         m_launchBall = false;
         ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       }
       ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
-      ShuffleboardHelper.m_entryBallsInStorage.setDouble(ballsInStorage);
+      ShuffleboardHelper.m_entryBallsInStorage.setDouble(m_ballsInStorage);
     } else if (ballDetectedExit) {
       ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
     }
@@ -449,13 +449,13 @@ public class Robot extends TimedRobot {
       m_motorBelt.set(advanceBelt ? Constants.kSpeedBelt : 0);
 
     // Rev up the launcher motors as soon as we start collecting balls.
-    if (ballsInStorage >= 1)
+    if (m_ballsInStorage >= 1)
       m_motorLauncherLeft.set(Constants.kSpeedLauncher);
     else
       m_motorLauncherLeft.set(0);
 
-    ballDetectedEnterLastLoop = ballDetectedEnter;
-    ballDetectedExitLastLoop = ballDetectedExit;
+    m_ballDetectedEnterLastLoop = ballDetectedEnter;
+    m_ballDetectedExitLastLoop = ballDetectedExit;
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -73,8 +73,8 @@ public class Robot extends TimedRobot {
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorEnter);
   private final DigitalInput m_photoelectricSensorExit =
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorExit);
-  private boolean m_ballDetectedEnterLastLoop = false;
   private int m_ballsInStorage = 0;
+  private boolean m_ballDetectedEnterLastLoop = false;
   private boolean m_ballDetectedExitLastLoop = false;
 
   // Launching
@@ -202,11 +202,11 @@ public class Robot extends TimedRobot {
     // robot is disabled.
     handleState();
 
-    m_ballDetectedEnterLastLoop = false;
     m_ballsInStorage = 0;
+    m_ballDetectedEnterLastLoop = false;
     m_ballDetectedExitLastLoop = false;
-    ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(false);
     ShuffleboardHelper.m_entryBallsInStorage.setDouble(m_ballsInStorage);
+    ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(false);
     ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(false);
   }
 
@@ -424,8 +424,8 @@ public class Robot extends TimedRobot {
         m_launchBall = false;
         ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       }
-      ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
       ShuffleboardHelper.m_entryBallsInStorage.setDouble(m_ballsInStorage);
+      ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
     } else if (ballDetectedExit) {
       ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
     }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -69,9 +69,9 @@ public class Robot extends TimedRobot {
       new WPI_TalonSRX(RoboRIO.kPortMotorIntake);
   private final WPI_VictorSPX m_motorBelt =
       new WPI_VictorSPX(RoboRIO.kPortMotorBelt);
-  private final DigitalInput photoelectricSensorEnter =
+  private final DigitalInput m_photoelectricSensorEnter =
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorEnter);
-  private final DigitalInput photoelectricSensorExit =
+  private final DigitalInput m_photoelectricSensorExit =
       new DigitalInput(RoboRIO.kPortPhotoelectricSensorExit);
   private boolean m_ballDetectedEnterLastLoop = false;
   private int m_ballsInStorage = 0;
@@ -401,8 +401,8 @@ public class Robot extends TimedRobot {
     boolean advanceBelt = false;
     // The digital input returns "true" if the circuit is open. Detecting the
     // object, the power cell, closes the circuit.
-    boolean ballDetectedEnter = !photoelectricSensorEnter.get();
-    boolean ballDetectedExit = !photoelectricSensorExit.get();
+    boolean ballDetectedEnter = !m_photoelectricSensorEnter.get();
+    boolean ballDetectedExit = !m_photoelectricSensorExit.get();
     // Advance the belt if there's a ball in the enter spot, and more room above.
     if (ballDetectedEnter) {
       if (!m_ballDetectedEnterLastLoop)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -274,17 +274,17 @@ public class Robot extends TimedRobot {
    */
   private void updateInputs() {
     m_buttonManipPressA =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonA);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonA);
     m_buttonManipPressB =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonB);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonB);
     m_buttonManipPressX =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonX);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonX);
     m_buttonManipPressY =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonY);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonY);
     m_buttonManipPressBack =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonBack);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonBack);
     m_buttonManipPressStart =
-        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonStart);
+        m_controllerManip.getRawButtonPressed(DriveStation.kIdButtonStart);
     int pov = m_controllerManip.getPOV(DriveStation.kIdPovDpad);
     if (pov != -1 && pov == m_povLastLoop)
       pov = -1;
@@ -325,9 +325,9 @@ public class Robot extends TimedRobot {
     }
 
     // If control panel mode is enabled and the robot is driven, disable it.
-    if ((Math.abs(m_controllerDrive.getRawAxis(DriveStation.kIDAxisLeftY)) > 0.5
+    if ((Math.abs(m_controllerDrive.getRawAxis(DriveStation.kIdAxisLeftY)) > 0.5
         || Math.abs(
-            m_controllerDrive.getRawAxis(DriveStation.kIDAxisRightX)) > 0.5)
+            m_controllerDrive.getRawAxis(DriveStation.kIdAxisRightX)) > 0.5)
         && m_isInControlPanelMode) {
       m_isInControlPanelMode = false;
       ShuffleboardHelper.m_entryControlPanelMode
@@ -366,17 +366,17 @@ public class Robot extends TimedRobot {
     // The drive controller is negated here due to the y-axes of the joystick being
     // opposite by default.
     double axisDriveLeftY =
-        -m_controllerDrive.getRawAxis(DriveStation.kIDAxisLeftY);
+        -m_controllerDrive.getRawAxis(DriveStation.kIdAxisLeftY);
     double speed = Math.signum(axisDriveLeftY) * Math.pow(axisDriveLeftY, 2);
     // Right thumb stick of the driver's joystick.
     double axisDriveRightX =
-        m_controllerDrive.getRawAxis(DriveStation.kIDAxisRightX);
+        m_controllerDrive.getRawAxis(DriveStation.kIdAxisRightX);
     double zRotation =
         Math.signum(axisDriveRightX) * Math.pow(axisDriveRightX, 2);
     // Left trigger of the driver's joystick.
-    double axisDriveLT = m_controllerDrive.getRawAxis(DriveStation.kIDAxisLT);
+    double axisDriveLT = m_controllerDrive.getRawAxis(DriveStation.kIdAxisLt);
     // Right trigger of the driver's joystick.
-    double axisDriveRT = m_controllerDrive.getRawAxis(DriveStation.kIDAxisRT);
+    double axisDriveRT = m_controllerDrive.getRawAxis(DriveStation.kIdAxisRt);
 
     // Setting robot drive speed.
     if (axisDriveLT > 0.5) {
@@ -394,7 +394,7 @@ public class Robot extends TimedRobot {
   private void intakeBalls() {
     // If the manipulator holds LT, and the storage isn't full, activate the intake.
     // TODO: Is this ballsInStorage check putting too much trust in the sensor?
-    if (m_controllerDrive.getRawAxis(DriveStation.kIDAxisLT) > 0.50
+    if (m_controllerDrive.getRawAxis(DriveStation.kIdAxisLt) > 0.50
         && ballsInStorage < 3)
       m_motorIntake.set(Constants.kSpeedIntake);
     else
@@ -439,9 +439,9 @@ public class Robot extends TimedRobot {
       advanceBelt = true;
 
     // If a manipulator bumper is held, disregard all of the previous logic, and force a belt movement.
-    if (m_controllerManip.getRawButton(DriveStation.kIDButtonRB))
+    if (m_controllerManip.getRawButton(DriveStation.kIdButtonRb))
       m_motorBelt.set(Constants.kSpeedBelt);
-    else if (m_controllerManip.getRawButton(DriveStation.kIDButtonLB))
+    else if (m_controllerManip.getRawButton(DriveStation.kIdButtonLb))
       m_motorBelt.set(-Constants.kSpeedBelt);
     // Use the logic based off of the photosensors for belt movement.
     else
@@ -482,7 +482,7 @@ public class Robot extends TimedRobot {
 
     // If the manipulator trigger is held, override our autonomous logic and manually spin up the
     // launcher.
-    if (m_controllerDrive.getRawAxis(DriveStation.kIDAxisRT) > 0.5)
+    if (m_controllerDrive.getRawAxis(DriveStation.kIdAxisRt) > 0.5)
       m_motorLauncherLeft.set(Constants.kSpeedLauncher);
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -142,6 +142,7 @@ public class Robot extends TimedRobot {
     m_colorMatcher.addColorMatch(kRedTarget);
     m_colorMatcher.addColorMatch(kYellowTarget);
 
+    ShuffleboardHelper.shuffleboardInit();
     // Add Shuffleboard sendables. We define the NetworkTableEntry objects as member
     // variables when adding those widgets because we need to access them to update
     // them. Contrary, we don't assign these widgets to any variables because, as

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -481,7 +481,8 @@ public class Robot extends TimedRobot {
 
       double error = Constants.kProjectedHorDistanceToApex - horDistanceToHoop;
       if (Math.abs(error) > tolerance) {
-        // m_differentialDrive.arcadeDrive(error * Constants.kP, 0);
+        // TODO: Very experimental! Fine tune this.
+        m_differentialDrive.arcadeDrive(error * Constants.kP, 0);
       } else {
         m_launchBall = true;
         ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -354,6 +354,7 @@ public class Robot extends TimedRobot {
       ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
     }
     m_isInControlPanelModeLastLoop = m_isInControlPanelMode;
+    m_isInLaunchingModeLastLoop = m_isInLaunchingMode;
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -196,9 +196,8 @@ public class Robot extends TimedRobot {
     ShuffleboardHelper.m_entryControlPanelMode
         .setBoolean(m_isInControlPanelMode);
     m_isInLaunchingMode = false;
-    m_isInLaunchingModeLastLoop = false;
-    ShuffleboardHelper.m_entryLaunchingMode
-        .setBoolean(m_isInLaunchingMode);
+    m_isInLaunchingModeLastLoop = true;
+    ShuffleboardHelper.m_entryLaunchingMode.setBoolean(m_isInLaunchingMode);
     // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
     // robot is disabled.
     handleState();

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -376,15 +376,15 @@ public class Robot extends TimedRobot {
     double zRotation =
         Math.signum(axisDriveRightX) * Math.pow(axisDriveRightX, 2);
     // Left trigger of the driver's joystick.
-    double axisDriveLT = m_controllerDrive.getRawAxis(DriveStation.kIdAxisLt);
+    double axisDriveLt = m_controllerDrive.getRawAxis(DriveStation.kIdAxisLt);
     // Right trigger of the driver's joystick.
-    double axisDriveRT = m_controllerDrive.getRawAxis(DriveStation.kIdAxisRt);
+    double axisDriveRt = m_controllerDrive.getRawAxis(DriveStation.kIdAxisRt);
 
     // Setting robot drive speed.
-    if (axisDriveLT > 0.5) {
+    if (axisDriveLt > 0.5) {
       m_differentialDrive.arcadeDrive(speed * Constants.kMultiplierSlowSpeed,
           zRotation * Constants.kMultiplierSlowSpeed, false);
-    } else if (axisDriveRT > 0.5) {
+    } else if (axisDriveRt > 0.5) {
       m_differentialDrive.arcadeDrive(speed * Constants.kMultiplierHighSpeed,
           zRotation * Constants.kMultiplierHighSpeed, false);
     } else {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -38,6 +38,7 @@ public class Robot extends TimedRobot {
   private boolean m_buttonManipPressDpadLeft = false;
   private boolean m_buttonManipPressDpadUp = false;
   private boolean m_buttonManipPressDpadRight = false;
+  private boolean m_buttonManipPressDpadDown = false;
 
   // State
   private boolean m_isInLaunchingMode = false;
@@ -284,6 +285,7 @@ public class Robot extends TimedRobot {
     m_buttonManipPressDpadLeft = pov == 270;
     m_buttonManipPressDpadUp = pov == 0;
     m_buttonManipPressDpadRight = pov == 90;
+    m_buttonManipPressDpadDown = pov == 180;
     m_povLastLoop = pov;
   }
 
@@ -522,6 +524,8 @@ public class Robot extends TimedRobot {
         m_controlPanelSpinAmount = 8;
       else if (m_buttonManipPressDpadRight)
         m_controlPanelSpinAmount = 10;
+      else if (m_buttonManipPressDpadDown)
+        m_controlPanelSpinAmount = 0;
       if (controlPanelSpinAmountInitial != m_controlPanelSpinAmount)
         ShuffleboardHelper.m_entryTargetSpin
             .setDouble(m_controlPanelSpinAmount);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -31,7 +31,12 @@ public class Robot extends TimedRobot {
   private boolean m_buttonManipPressB = false;
   private boolean m_buttonManipPressX = false;
   private boolean m_buttonManipPressY = false;
+  private boolean m_buttonManipPressBack = false;
   private boolean m_buttonManipPressStart = false;
+  private int m_povLastLoop = -1;
+  private boolean m_buttonManipPressDpadLeft = false;
+  private boolean m_buttonManipPressDpadUp = false;
+  private boolean m_buttonManipPressDpadRight = false;
 
   // State
   private boolean m_isInControlPanelMode = false;
@@ -243,8 +248,17 @@ public class Robot extends TimedRobot {
         m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonX);
     m_buttonManipPressY =
         m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonY);
+    m_buttonManipPressBack =
+        m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonBack);
     m_buttonManipPressStart =
         m_controllerManip.getRawButtonPressed(DriveStation.kIDButtonStart);
+    int pov = m_controllerManip.getPOV(DriveStation.kIdPovDpad);
+    if (pov != -1 && pov == m_povLastLoop)
+      pov = -1;
+    m_buttonManipPressDpadLeft = pov == 270;
+    m_buttonManipPressDpadUp = pov == 0;
+    m_buttonManipPressDpadRight = pov == 90;
+    m_povLastLoop = pov;
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -479,6 +479,8 @@ public class Robot extends TimedRobot {
             ? Math.min(Constants.kMultiplierHighSpeed, error * Constants.kP)
             : Math.max(-Constants.kMultiplierHighSpeed, error * Constants.kP),
             0, false);
+        m_launchBall = false;
+        ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       } else {
         m_differentialDrive.arcadeDrive(0, 0);
         m_launchBall = true;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -359,35 +359,30 @@ public class Robot extends TimedRobot {
    */
   private void spinControlPanel() {
     if (m_isInControlPanelMode) {
-      if (m_controllerManip.getRawButton(DriveStation.kIDButtonRB)) {
-        int controlPanelSpinAmountInitial = m_controlPanelSpinAmount;
-        // During a match, the amount of revolutions needed to be completed will be
-        // specified as either 3, 4, or 5. The selections below display 6, 8, and 10,
-        // respectively, because each color is represented twice on the control panel.
-        if (m_buttonManipPressA)
-          m_controlPanelSpinAmount = 6;
-        else if (m_buttonManipPressB)
-          m_controlPanelSpinAmount = 8;
-        else if (m_buttonManipPressX)
-          m_controlPanelSpinAmount = 10;
+      String targetControlPanelColorInitial = m_targetControlPanelColor;
+      if (m_buttonManipPressA)
+        m_targetControlPanelColor = "Green";
+      else if (m_buttonManipPressB)
+        m_targetControlPanelColor = "Red";
+      else if (m_buttonManipPressX)
+        m_targetControlPanelColor = "Blue";
+      else if (m_buttonManipPressY)
+        m_targetControlPanelColor = "Yellow";
+      if (targetControlPanelColorInitial != m_targetControlPanelColor)
+      ShuffleboardHelper.m_entryTargetColor.setString(m_targetControlPanelColor);
 
-        if (controlPanelSpinAmountInitial != m_controlPanelSpinAmount)
-          ShuffleboardHelper.m_entryTargetSpin
-              .setDouble(m_controlPanelSpinAmount);
-      } else {
-        String targetControlPanelColorInitial = m_targetControlPanelColor;
-        if (m_buttonManipPressA)
-          m_targetControlPanelColor = "Green";
-        else if (m_buttonManipPressB)
-          m_targetControlPanelColor = "Red";
-        else if (m_buttonManipPressX)
-          m_targetControlPanelColor = "Blue";
-        else if (m_buttonManipPressY)
-          m_targetControlPanelColor = "Yellow";
-        if (targetControlPanelColorInitial != m_targetControlPanelColor)
-          ShuffleboardHelper.m_entryTargetColor
-              .setString(m_targetControlPanelColor);
-      }
+      int controlPanelSpinAmountInitial = m_controlPanelSpinAmount;
+      // During a match, the amount of revolutions needed to be completed will be
+      // specified as either 3, 4, or 5. The selections below display 6, 8, and 10,
+      // respectively, because each color is represented twice on the control panel.
+      if (m_buttonManipPressDpadLeft)
+        m_controlPanelSpinAmount = 6;
+      else if (m_buttonManipPressDpadUp)
+        m_controlPanelSpinAmount = 8;
+      else if (m_buttonManipPressDpadRight)
+        m_controlPanelSpinAmount = 10;
+      if (controlPanelSpinAmountInitial != m_controlPanelSpinAmount)
+      ShuffleboardHelper.m_entryTargetSpin.setDouble(m_controlPanelSpinAmount);
 
       Color detectedColor = m_colorSensor.getColor();
       ColorMatchResult match = m_colorMatcher.matchClosestColor(detectedColor);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -80,8 +80,8 @@ public class Robot extends TimedRobot {
   // Launching
   WPI_VictorSPX m_motorLauncherLeft =
       new WPI_VictorSPX(RoboRIO.kPortMotorLauncherLeft);
-  WPI_VictorSPX m_motorLauncherRight =
-      new WPI_VictorSPX(RoboRIO.kPortMotorLauncherRight);
+  WPI_TalonSRX m_motorLauncherRight =
+      new WPI_TalonSRX(RoboRIO.kPortMotorLauncherRight);
   private final AnalogInput m_analogInputUltrasonicSensor =
       new AnalogInput(RoboRIO.kPortUltrasonicSensorPort);
   // Leave this uninitialized because we have to configure the analog input.

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -346,7 +346,7 @@ public class Robot extends TimedRobot {
     if (!m_isInLaunchingMode
         && m_isInLaunchingModeLastLoop != m_isInLaunchingMode) {
       m_launchBall = false;
-      ShuffleboardHelper.m_entryLaunchBall.setBoolean(false);
+      ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
     }
     m_isInControlPanelModeLastLoop = m_isInControlPanelMode;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -122,9 +122,6 @@ public class Robot extends TimedRobot {
     m_motorDriveBackLeft.follow(m_motorDriveFrontLeft);
 
     m_motorLauncherRight.follow(m_motorLauncherLeft);
-    // Invert one of the launching motors, because they must spin in opposite
-    // directions.
-    m_motorLauncherRight.setInverted(true);
 
     // Configure the ultrasonic sensor.
     // Enable 2-bit averaging, for stability,

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -447,7 +447,14 @@ public class Robot extends TimedRobot {
     if (m_launchBall)
       advanceBelt = true;
 
-    m_motorBelt.set(advanceBelt ? Constants.kSpeedBelt : 0);
+    // If a manipulator bumper is held, disregard all of the previous logic, and force a belt movement.
+    if (m_controllerManip.getRawButton(DriveStation.kIDButtonRB))
+      m_motorBelt.set(Constants.kSpeedBelt);
+    else if (m_controllerManip.getRawButton(DriveStation.kIDButtonLB))
+      m_motorBelt.set(-Constants.kSpeedBelt);
+    // Use the logic based off of the photosensors for belt movement.
+    else
+      m_motorBelt.set(advanceBelt ? Constants.kSpeedBelt : 0);
 
     // Rev up the launcher motors as soon as we start collecting balls.
     if (ballsInStorage >= 1)

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -41,6 +41,7 @@ public class Robot extends TimedRobot {
 
   // State
   private boolean m_isInLaunchingMode = false;
+  private boolean m_isInLaunchingModeLastLoop = false;
   private boolean m_isInControlPanelMode = false;
   private boolean m_isInControlPanelModeLastLoop = false;
 
@@ -234,6 +235,7 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     m_isInLaunchingMode = false;
+    m_isInLaunchingModeLastLoop = false;
     m_isInControlPanelMode = false;
     m_isInControlPanelModeLastLoop = false;
 
@@ -344,6 +346,12 @@ public class Robot extends TimedRobot {
           .setString(m_targetControlPanelColor);
       ShuffleboardHelper.m_entryTargetSpin.setDouble(m_controlPanelSpinAmount);
       ShuffleboardHelper.m_entryConfidence.setDouble(0);
+    }
+    if (!m_isInLaunchingMode
+        && m_isInLaunchingModeLastLoop != m_isInLaunchingMode) {
+      m_launchBall = false;
+      ShuffleboardHelper.m_entryLaunchBall.setBoolean(false);
+      ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
     }
     m_isInControlPanelModeLastLoop = m_isInControlPanelMode;
   }
@@ -470,11 +478,6 @@ public class Robot extends TimedRobot {
         m_launchBall = true;
         ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       }
-    } else {
-      // TODO: Move this stuff into handleState, and only do this when the mode has just been switched.
-      ShuffleboardHelper.m_entryDistanceSensor.setDouble(0);
-      m_launchBall = false;
-      ShuffleboardHelper.m_entryLaunchBall.setBoolean(false);
     }
 
     // If the manipulator trigger is held, override our autonomous logic and manually spin up the

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -474,7 +474,12 @@ public class Robot extends TimedRobot {
       double error = Constants.kProjectedHorDistanceToApex - horDistanceToHoop;
       if (Math.abs(error) > tolerance) {
         // TODO: Very experimental! Fine tune this.
-        m_differentialDrive.arcadeDrive(error * Constants.kP, 0);
+        // Cap out the correction speed at the higher driving speed. Don't square the inputs because this
+        // isn't from an analog stick, so that kind of precision isn't necessary.
+        m_differentialDrive.arcadeDrive(error > 0
+            ? Math.min(Constants.kMultiplierHighSpeed, error * Constants.kP)
+            : Math.max(-Constants.kMultiplierHighSpeed, error * Constants.kP),
+            0, false);
       } else {
         m_differentialDrive.arcadeDrive(0, 0);
         m_launchBall = true;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -476,6 +476,7 @@ public class Robot extends TimedRobot {
         // TODO: Very experimental! Fine tune this.
         m_differentialDrive.arcadeDrive(error * Constants.kP, 0);
       } else {
+        m_differentialDrive.arcadeDrive(0, 0);
         m_launchBall = true;
         ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -108,23 +108,6 @@ public class Robot extends TimedRobot {
 
   // Vision
 
-  private final ShuffleboardLayout ballIntakeLayout =
-      m_tabGeneral.getLayout("Ball Intake", BuiltInLayouts.kGrid)
-          .withPosition(0, 4).withSize(3, 1)
-          .withProperties(Map.of("Number of columns", 4, "Number of rows", 1));
-  private final NetworkTableEntry ballsInStorageEntry = ballIntakeLayout
-      .add("Balls in storage", 0).withWidget(BuiltInWidgets.kNumberBar)
-      .withProperties(Map.of("Min", 0, "Max", 3, "Center", 0)).getEntry();
-  private final NetworkTableEntry ballDetectedEnterEntry =
-      ballIntakeLayout.add("Ball detected at entrance point", false)
-          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
-  private final NetworkTableEntry ballDetectedExitEntry =
-      ballIntakeLayout.add("Ball detected at leave", false)
-          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
-  private final NetworkTableEntry m_entryLaunchBall =
-      ballIntakeLayout.add("Launching balls", false)
-          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
-
   /**
    * Initializes the robot code when the robot power is turned on.
    */
@@ -421,10 +404,10 @@ public class Robot extends TimedRobot {
         ++ballsInStorage;
       if (ballsInStorage < 3)
         advanceBelt = true;
-      ballDetectedEnterEntry.setBoolean(ballDetectedEnter);
-      ballsInStorageEntry.setDouble(ballsInStorage);
+      ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(ballDetectedEnter);
+      ShuffleboardHelper.m_entryBallsInStorage.setDouble(ballsInStorage);
     } else if (!ballDetectedEnter) {
-      ballDetectedEnterEntry.setBoolean(ballDetectedEnter);
+      ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(ballDetectedEnter);
       advanceBelt = false;
     }
     // Keep track of balls exiting.
@@ -434,12 +417,12 @@ public class Robot extends TimedRobot {
       // Stop launching the balls if we have finished.
       if (m_launchBall && ballsInStorage == 0) {
         m_launchBall = false;
-        m_entryLaunchBall.setBoolean(m_launchBall);
+        ShuffleboardHelper.m_entryLaunchBall.setBoolean(m_launchBall);
       }
-      ballDetectedExitEntry.setBoolean(ballDetectedExit);
-      ballsInStorageEntry.setDouble(ballsInStorage);
+      ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
+      ShuffleboardHelper.m_entryBallsInStorage.setDouble(ballsInStorage);
     } else if (ballDetectedExit) {
-      ballDetectedExitEntry.setBoolean(ballDetectedExit);
+      ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(ballDetectedExit);
     }
 
     // If we are ready to launch the ball, override the false advanceBelt from the storage being full.

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -492,6 +492,11 @@ public class Robot extends TimedRobot {
       m_launchBall = false;
       ShuffleboardHelper.m_entryLaunchBall.setBoolean(false);
     }
+
+    // If the manipulator trigger is held, override our autonomous logic and manually spin up the
+    // launcher.
+    if (m_controllerDrive.getRawAxis(DriveStation.kIDAxisRT) > 0.5)
+      m_motorLauncherLeft.set(Constants.kSpeedLauncher);
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -194,9 +194,20 @@ public class Robot extends TimedRobot {
     m_isInControlPanelModeLastLoop = true;
     ShuffleboardHelper.m_entryControlPanelMode
         .setBoolean(m_isInControlPanelMode);
+    m_isInLaunchingMode = false;
+    m_isInLaunchingModeLastLoop = false;
+    ShuffleboardHelper.m_entryLaunchingMode
+        .setBoolean(m_isInLaunchingMode);
     // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
     // robot is disabled.
     handleState();
+
+    m_ballDetectedEnterLastLoop = false;
+    m_ballsInStorage = 0;
+    m_ballDetectedExitLastLoop = false;
+    ShuffleboardHelper.m_entryBallDetectedEnter.setBoolean(false);
+    ShuffleboardHelper.m_entryBallsInStorage.setDouble(m_ballsInStorage);
+    ShuffleboardHelper.m_entryBallDetectedExit.setBoolean(false);
   }
 
   /**
@@ -234,21 +245,6 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void teleopInit() {
-    m_isInLaunchingMode = false;
-    m_isInLaunchingModeLastLoop = false;
-    m_isInControlPanelMode = false;
-    m_isInControlPanelModeLastLoop = false;
-
-    m_ballDetectedEnterLastLoop = false;
-    m_ballsInStorage = 0;
-
-    m_launchBall = false;
-
-    m_detectedColorString = "N/A";
-    m_lastDetectedColorString = "N/A";
-    m_targetControlPanelColor = "N/A";
-    m_controlPanelSpinAmount = 0;
-
     m_compressor.start();
 
     disabledInit();

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -67,7 +67,7 @@ public final class ShuffleboardHelper {
           .withWidget(BuiltInWidgets.kNumberBar)
           .withProperties(kPropertiesDistanceSensor).getEntry();
   public static final NetworkTableEntry m_entryDistanceTolerence =
-      m_layoutLaunching.addPersistent("Distance Tolerance", 0.3)
+      m_layoutLaunching.addPersistent("Distance Tolerance", 0.25)
           .withWidget(BuiltInWidgets.kNumberSlider)
           .withProperties(
               Map.of("Min", 0.0, "Max", 2.0, "Block increment", 0.25))

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -130,6 +130,22 @@ public final class ShuffleboardHelper {
   public static final Timer m_timerSim = new Timer();
   public static boolean m_isRunningSim = false;
 
+  public static void shuffleboardInit() {
+    m_entryControlPanelMode.setBoolean(false);
+    m_entryLaunchingMode.setBoolean(false);
+
+    m_entryBallsInStorage.setBoolean(false);
+    m_entryBallDetectedEnter.setBoolean(false);
+    m_entryBallDetectedExit.setBoolean(false);
+    m_entryLaunchBall.setBoolean(false);
+
+    m_entryDistanceSensor.setDouble(0);
+
+    m_entryDetectedColor.setString("N/A");
+    m_entryTargetColor.setDouble(0);
+    m_entryTargetSpin.setDouble(0);
+  }
+
   /**
    * This function is called upon in the simulationPeriodic() method of Robot.java.
    */

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -70,7 +70,7 @@ public final class ShuffleboardHelper {
           .withWidget(BuiltInWidgets.kNumberBar)
           .withProperties(kPropertiesDistanceSensor).getEntry();
   public static final NetworkTableEntry m_entryDistanceTolerence =
-      m_layoutLaunching.addPersistent("Distance Tolerance", 1)
+      m_layoutLaunching.addPersistent("Distance Tolerance", 0.3)
           .withWidget(BuiltInWidgets.kNumberSlider)
           .withProperties(
               Map.of("Min", 0.0, "Max", 2.0, "Block increment", 0.25))

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -20,7 +20,10 @@ public final class ShuffleboardHelper {
   public static final ShuffleboardLayout m_layoutState =
       m_tabGeneral.getLayout("State", BuiltInLayouts.kGrid).withPosition(0, 0)
           .withSize(3, 1)
-          .withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
+          .withProperties(Map.of("Number of columns", 2, "Number of rows", 1));
+  public static final NetworkTableEntry m_entryLaunchingMode =
+      m_layoutState.add("Launching mode", false)
+          .withWidget(BuiltInWidgets.kToggleSwitch).getEntry();
   public static final NetworkTableEntry m_entryControlPanelMode =
       m_layoutState.add("Control panel mode", false)
           .withWidget(BuiltInWidgets.kToggleSwitch).getEntry();
@@ -32,6 +35,23 @@ public final class ShuffleboardHelper {
       m_tabGeneral.getLayout("Driving", BuiltInLayouts.kGrid).withPosition(0, 1)
           .withSize(3, 3)
           .withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
+  public static final ShuffleboardLayout m_layoutBallIntake =
+      m_tabGeneral.getLayout("Ball Intake", BuiltInLayouts.kGrid)
+          .withPosition(0, 4).withSize(3, 1)
+          .withProperties(Map.of("Number of columns", 4, "Number of rows", 1));
+  public static final NetworkTableEntry m_entryBallsInStorage =
+      m_layoutBallIntake.add("Balls in storage", 0)
+          .withWidget(BuiltInWidgets.kNumberBar)
+          .withProperties(Map.of("Min", 0, "Max", 3, "Center", 0)).getEntry();
+  public static final NetworkTableEntry m_entryBallDetectedEnter =
+      m_layoutBallIntake.add("Ball detected at entrance point", false)
+          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
+  public static final NetworkTableEntry m_entryBallDetectedExit =
+      m_layoutBallIntake.add("Ball detected at leave", false)
+          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
+  public static final NetworkTableEntry m_entryLaunchBall =
+      m_layoutBallIntake.add("Launching balls", false)
+          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
   public static final ShuffleboardLayout m_layoutLaunching =
       m_tabGeneral.getLayout("Launching", BuiltInLayouts.kGrid)
           .withPosition(3, 1).withSize(3, 3)

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -131,7 +131,7 @@ public final class ShuffleboardHelper {
   public static boolean m_isRunningSim = false;
 
   /**
-   * This function is called upon in the robotPeriodic() method of Robot.java.
+   * This function is called upon in the simulationPeriodic() method of Robot.java.
    */
   public static void updateSimulations() {
     if (m_entryRunPred.getBoolean(false)) {

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -17,6 +17,7 @@ public final class ShuffleboardHelper {
   // Shuffleboard General
   public static final ShuffleboardTab m_tabGeneral =
       Shuffleboard.getTab("General");
+
   public static final ShuffleboardLayout m_layoutState =
       m_tabGeneral.getLayout("State", BuiltInLayouts.kGrid).withPosition(0, 0)
           .withSize(3, 1)
@@ -27,14 +28,17 @@ public final class ShuffleboardHelper {
   public static final NetworkTableEntry m_entryControlPanelMode =
       m_layoutState.add("Control panel mode", false)
           .withWidget(BuiltInWidgets.kToggleSwitch).getEntry();
+
   public static final ShuffleboardLayout m_layoutAutonomous = m_tabGeneral
       .getLayout("Autonomous", BuiltInLayouts.kGrid).withPosition(3, 0)
       .withSize(3, 1).withProperties(Map.of("Label position", "HIDDEN",
           "Number of columns", 1, "Number of rows", 1));
+
   public static final ShuffleboardLayout m_layoutDriving =
       m_tabGeneral.getLayout("Driving", BuiltInLayouts.kGrid).withPosition(0, 1)
           .withSize(3, 3)
           .withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
+
   public static final ShuffleboardLayout m_layoutBallIntake =
       m_tabGeneral.getLayout("Ball Intake", BuiltInLayouts.kGrid)
           .withPosition(0, 4).withSize(3, 1)
@@ -52,6 +56,7 @@ public final class ShuffleboardHelper {
   public static final NetworkTableEntry m_entryLaunchBall =
       m_layoutBallIntake.add("Launching balls", false)
           .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
+
   public static final ShuffleboardLayout m_layoutLaunching =
       m_tabGeneral.getLayout("Launching", BuiltInLayouts.kGrid)
           .withPosition(3, 1).withSize(3, 3)
@@ -70,6 +75,7 @@ public final class ShuffleboardHelper {
           .withProperties(
               Map.of("Min", 0.0, "Max", 2.0, "Block increment", 0.25))
           .getEntry();
+
   public static final ShuffleboardLayout m_layoutControlPanel =
       m_tabGeneral.getLayout("Color Sensing", BuiltInLayouts.kGrid)
           .withPosition(3, 4).withSize(3, 2)
@@ -82,6 +88,7 @@ public final class ShuffleboardHelper {
       m_layoutControlPanel.add("Target Color", "N/A").getEntry();
   public static final NetworkTableEntry m_entryTargetSpin =
       m_layoutControlPanel.add("Target Spins", 0).getEntry();
+
   public static final ShuffleboardLayout m_layoutVision =
       m_tabGeneral.getLayout("Vision", BuiltInLayouts.kGrid).withPosition(6, 0)
           .withSize(1, 1)

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -35,26 +35,23 @@ public final class ShuffleboardHelper {
           "Number of columns", 1, "Number of rows", 1));
 
   public static final ShuffleboardLayout m_layoutDriving =
-      m_tabGeneral.getLayout("Driving", BuiltInLayouts.kGrid).withPosition(0, 1)
-          .withSize(3, 3)
+      m_tabGeneral.getLayout("Driving (Read only)", BuiltInLayouts.kGrid)
+          .withPosition(0, 1).withSize(3, 3)
           .withProperties(Map.of("Number of columns", 1, "Number of rows", 1));
 
   public static final ShuffleboardLayout m_layoutBallIntake =
-      m_tabGeneral.getLayout("Ball Intake", BuiltInLayouts.kGrid)
+      m_tabGeneral.getLayout("Ball Intake (Read only)", BuiltInLayouts.kGrid)
           .withPosition(0, 4).withSize(3, 1)
-          .withProperties(Map.of("Number of columns", 4, "Number of rows", 1));
+          .withProperties(Map.of("Number of columns", 3, "Number of rows", 1));
   public static final NetworkTableEntry m_entryBallsInStorage =
       m_layoutBallIntake.add("Balls in storage", 0)
           .withWidget(BuiltInWidgets.kNumberBar)
           .withProperties(Map.of("Min", 0, "Max", 3, "Center", 0)).getEntry();
   public static final NetworkTableEntry m_entryBallDetectedEnter =
-      m_layoutBallIntake.add("Ball detected at entrance point", false)
+      m_layoutBallIntake.add("Ball @ Enter", false)
           .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
   public static final NetworkTableEntry m_entryBallDetectedExit =
-      m_layoutBallIntake.add("Ball detected at leave", false)
-          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
-  public static final NetworkTableEntry m_entryLaunchBall =
-      m_layoutBallIntake.add("Launching balls", false)
+      m_layoutBallIntake.add("Ball @ Exit", false)
           .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
 
   public static final ShuffleboardLayout m_layoutLaunching =
@@ -75,9 +72,12 @@ public final class ShuffleboardHelper {
           .withProperties(
               Map.of("Min", 0.0, "Max", 2.0, "Block increment", 0.25))
           .getEntry();
+  public static final NetworkTableEntry m_entryLaunchBall =
+      m_layoutLaunching.add("Launching balls", false)
+          .withWidget(BuiltInWidgets.kBooleanBox).getEntry();
 
   public static final ShuffleboardLayout m_layoutControlPanel =
-      m_tabGeneral.getLayout("Color Sensing", BuiltInLayouts.kGrid)
+      m_tabGeneral.getLayout("Color Sensing (Read only)", BuiltInLayouts.kGrid)
           .withPosition(3, 4).withSize(3, 2)
           .withProperties(Map.of("Number of columns", 2, "Number of rows", 2));
   public static final NetworkTableEntry m_entryDetectedColor =


### PR DESCRIPTION
This PR:
- Adds a dedicated launching mode for the manipulator, in which the bot will autonomously adjust itself to make the shot into the hoop, vertically. Ensuring that the shot can be made horizontally will make this more complicated, but that can be addressed in a later pull request. 
- Adds D-pad inputs for the control panel. This only loosely relates to the main focus of this PR, but it is grouped together because of how I restructured some of the inputs in order to make launching mode flow well.
- Adds preliminary (very untested) code for using the photosensors to keep track of the balls.
- Adds Shuffleboard telemetry for keeping track of the ball status.
- Spins up the launching motor when there are enough balls in storage.