### PR TITLE
More fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "java.configuration.updateBuildConfiguration": "automatic",
+  // Exclude files from the explorer that we don't care about.
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
@@ -13,5 +13,12 @@
     "**/.factorypath": true,
     "**/*~": true
   },
-  "java.format.settings.url": "eclipse-formatter.xml"
+  // Set the tab size to 2.
+  "editor.tabSize": 2,
+  // Don't automatically detect indentation, because VSCode makes incorrect assumptions when doing so.
+  "editor.detectIndentation": false,
+  // Automatically update the classpath when new files are added.
+  "java.configuration.updateBuildConfiguration": "automatic",
+  // Use the WPILib Eclipse formatting rules.
+  "java.format.settings.url": "eclipse-formatter.xml",
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -287,7 +287,9 @@ public class Robot extends TimedRobot {
   }
 
   /**
-   * Drives the robot at a certain speed inputted by the driver.
+   * Drives the robot at a certain speed inputted by the driver. DifferentialDrive squares the input
+   * values by default, so in order to apply a speed modifier, we have to square it ourselves, so that
+   * it is squared before the modifier is applied.
    */
   private void driveSpeed() {
     // Left thumb stick of the driver's joystick.
@@ -295,27 +297,27 @@ public class Robot extends TimedRobot {
     // opposite by default.
     double axisDriveLeftY =
         -m_controllerDrive.getRawAxis(DriveStation.kIDAxisLeftY);
+    double speed = Math.signum(axisDriveLeftY) * Math.pow(axisDriveLeftY, 2);
     // Right thumb stick of the driver's joystick.
     double axisDriveRightX =
         m_controllerDrive.getRawAxis(DriveStation.kIDAxisRightX);
+    double zRotation =
+        Math.signum(axisDriveRightX) * Math.pow(axisDriveRightX, 2);
     // Left trigger of the driver's joystick.
     double axisDriveLT = m_controllerDrive.getRawAxis(DriveStation.kIDAxisLT);
     // Right trigger of the driver's joystick.
     double axisDriveRT = m_controllerDrive.getRawAxis(DriveStation.kIDAxisRT);
 
-    // Setting robot drive speed
+    // Setting robot drive speed.
     if (axisDriveLT > 0.5) {
-      m_differentialDrive.arcadeDrive(
-          axisDriveLeftY * Constants.kMultiplierSlowSpeed,
-          axisDriveRightX * Constants.kMultiplierSlowSpeed);
+      m_differentialDrive.arcadeDrive(speed * Constants.kMultiplierSlowSpeed,
+          zRotation * Constants.kMultiplierSlowSpeed, false);
     } else if (axisDriveRT > 0.5) {
-      m_differentialDrive.arcadeDrive(
-          axisDriveLeftY * Constants.kMultiplierHighSpeed,
-          axisDriveRightX * Constants.kMultiplierHighSpeed);
+      m_differentialDrive.arcadeDrive(speed * Constants.kMultiplierHighSpeed,
+          zRotation * Constants.kMultiplierHighSpeed, false);
     } else {
-      m_differentialDrive.arcadeDrive(
-          axisDriveLeftY * Constants.kMultiplierNormalSpeed,
-          axisDriveRightX * Constants.kMultiplierNormalSpeed);
+      m_differentialDrive.arcadeDrive(speed * Constants.kMultiplierNormalSpeed,
+          zRotation * Constants.kMultiplierNormalSpeed, false);
     }
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -213,6 +213,8 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     m_compressor.start();
+
+    disabledInit();
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -144,7 +144,6 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
-    ShuffleboardHelper.shuffleboardPeriodic();
   }
 
   /**
@@ -159,6 +158,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void simulationPeriodic() {
+    ShuffleboardHelper.updateSimulations();
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -168,7 +168,6 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     m_isInControlPanelMode = false;
-    m_isInControlPanelModeLastLoop = false;
     // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
     // robot is disabled.
     handleState();

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -168,6 +168,10 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     m_isInControlPanelMode = false;
+    // Force a state change.
+    m_isInControlPanelModeLastLoop = true;
+    ShuffleboardHelper.m_entryControlPanelMode
+        .setBoolean(m_isInControlPanelMode);
     // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
     // robot is disabled.
     handleState();

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -162,11 +162,13 @@ public class Robot extends TimedRobot {
   }
 
   /**
-   * Initializes disabled mode.
+   * Initializes disabled mode. This method is responsible for resetting state to the way it this
+   * class is when it's initialized.
    */
   @Override
   public void disabledInit() {
     m_isInControlPanelMode = false;
+    m_isInControlPanelModeLastLoop = false;
     // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
     // robot is disabled.
     handleState();
@@ -207,14 +209,6 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void teleopInit() {
-    m_isInControlPanelMode = false;
-    m_isInControlPanelModeLastLoop = false;
-
-    m_detectedColorString = "N/A";
-    m_lastDetectedColorString = "N/A";
-    m_targetControlPanelColor = "N/A";
-    m_controlPanelSpinAmount = 0;
-
     m_compressor.start();
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -166,10 +166,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void disabledInit() {
-    ShuffleboardHelper.m_entryDetectedColor.setString("N/A");
-    ShuffleboardHelper.m_entryConfidence.setDouble(0);
-    ShuffleboardHelper.m_entryTargetColor.setString("N/A");
-    ShuffleboardHelper.m_entryTargetSpin.setDouble(0);
+    m_isInControlPanelMode = false;
+    // Running this method will update Shuffleboard to show "N/A" and such, which is desirable while the
+    // robot is disabled.
+    handleState();
   }
 
   /**

--- a/src/main/java/frc/robot/ShuffleboardHelper.java
+++ b/src/main/java/frc/robot/ShuffleboardHelper.java
@@ -106,7 +106,7 @@ public final class ShuffleboardHelper {
   /**
    * This function is called upon in the robotPeriodic() method of Robot.java.
    */
-  public static void shuffleboardPeriodic() {
+  public static void updateSimulations() {
     if (m_entryRunPred.getBoolean(false)) {
       m_entryRunPred.setBoolean(false);
       double horDistance = m_entryHorizontalDistance.getDouble(0);


### PR DESCRIPTION
This pull request:
- Modifies the VSCode configuration to force tab sizes of 2 spaces.
- Moves Shuffleboard simulations to only run when we are simulating the robot code.
- Has `disabledInit()` forcefully turn off control panel mode, and reset its state.
- Has `teleopInit()` call `disabledInit()` in order to start with a clean state.
  - The current contents of the latter will have to change if we ever uninitialized stuff there.
- Fixes an issue with driving where the input speed would be modified before being square.